### PR TITLE
example: include GlobalTransform for better compatibility

### DIFF
--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -59,7 +59,7 @@ fn setup(
         AdditionalMassProperties::Mass(1.0),
         GravityScale(0.0),
         Ccd { enabled: true }, // Prevent clipping when going fast
-        Transform::from_xyz(0.0, 3.0, 0.0),
+        TransformBundle::from_transform(Transform::from_xyz(0.0, 3.0, 0.0)),
         LogicalPlayer(0),
         FpsControllerInput {
             pitch: -TAU / 12.0,


### PR DESCRIPTION
Using the example as a reference, I got stuck for a while because transform did not propagate through the hierarchy by virtue of a missing GlobalTransform component. While not affecting the example itself in any meaningful way, adding this component will make it easier for others that use it as a reference.

P.S.
Thank you for your work, I especially like the un-opinionated and unobtrusive API