### PR TITLE
Add crouching, update example, better sane defaults, minor fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,9 +1385,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -2027,14 +2027,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2365,9 +2365,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "optional"
@@ -2543,9 +2543,9 @@ checksum = "17fd96390ed3feda12e1dfe2645ed587e0bea749e319333f104a33ff62f77a0b"
 
 [[package]]
 name = "range-alloc"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e935c45e09cc6dcf00d2f0b2d630a58f4095320223d47fc68918722f0538b6"
+checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
 
 [[package]]
 name = "rapier3d"
@@ -2976,10 +2976,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if",
  "once_cell",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_fps_controller"
-version = "0.1.6-dev"
+version = "0.1.7-dev"
 edition = "2021"
 authors = ["bevy_fps_controller"]
 repository = "https://github.com/qhdwight/bevy_fps_controller"

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,7 +1,9 @@
 use std::f32::consts::TAU;
 
-use bevy::prelude::*;
-use bevy::window::CursorGrabMode;
+use bevy::{
+    prelude::*,
+    window::CursorGrabMode,
+};
 use bevy_rapier3d::prelude::*;
 
 use bevy_fps_controller::controller::*;
@@ -12,7 +14,7 @@ fn main() {
             color: Color::WHITE,
             brightness: 0.25,
         })
-        .insert_resource(ClearColor(Color::rgb(0.752, 0.992, 0.984)))
+        .insert_resource(ClearColor(Color::hex("D4F5F5").unwrap()))
         .insert_resource(RapierConfiguration::default())
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             window: WindowDescriptor {
@@ -51,6 +53,14 @@ fn setup(
     // where often time these two ideas are not exactly synced up
     commands.spawn((
         Collider::capsule(Vec3::Y * 0.5, Vec3::Y * 1.5, 0.5),
+        Friction {
+            coefficient: 0.0,
+            combine_rule: CoefficientCombineRule::Min,
+        },
+        Restitution {
+            coefficient: 0.0,
+            combine_rule: CoefficientCombineRule::Min,
+        },
         ActiveEvents::COLLISION_EVENTS,
         Velocity::zero(),
         RigidBody::Dynamic,
@@ -73,9 +83,9 @@ fn setup(
         RenderPlayer(0),
     ));
 
-    // World
-    commands.spawn_empty()
-        .insert(PbrBundle {
+    // Floor
+    commands.spawn((
+        PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Box {
                 min_x: -20.0,
                 max_x: 20.0,
@@ -85,18 +95,39 @@ fn setup(
                 max_z: 20.0,
             })),
             material: materials.add(StandardMaterial {
-                base_color: Color::hex("E6EED6").unwrap(),
+                base_color: Color::hex("8C9A9E").unwrap(),
                 ..default()
             }),
-            transform: Transform::IDENTITY,
+            transform: Transform::from_xyz(0.0, -0.25, 0.0),
             ..default()
-        })
-        .insert(Collider::cuboid(20.0, 0.25, 20.0))
-        .insert(RigidBody::Fixed)
-        .insert(Transform::IDENTITY);
+        },
+        Collider::cuboid(20.0, 0.25, 20.0),
+        RigidBody::Fixed,
+    ));
 
-    commands.spawn_empty()
-        .insert(PbrBundle {
+    let material = materials.add(StandardMaterial {
+        base_color: Color::hex("747578").unwrap(),
+        ..default()
+    });
+    commands.spawn((
+        PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Box {
+                min_x: -1.0,
+                max_x: 1.0,
+                min_y: -0.5,
+                max_y: 0.5,
+                min_z: -1.0,
+                max_z: 1.0,
+            })),
+            material: material.clone(),
+            transform: Transform::from_xyz(4.0, 0.5, 4.0),
+            ..default()
+        },
+        Collider::cuboid(1.0, 1.0, 1.0),
+        RigidBody::Fixed,
+    ));
+    commands.spawn((
+        PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Box {
                 min_x: -1.0,
                 max_x: 1.0,
@@ -105,16 +136,13 @@ fn setup(
                 min_z: -1.0,
                 max_z: 1.0,
             })),
-            material: materials.add(StandardMaterial {
-                base_color: Color::hex("DDE2C6").unwrap(),
-                ..default()
-            }),
-            transform: Transform::IDENTITY,
+            material: material.clone(),
+            transform: Transform::from_xyz(2.0, 1.0, 4.0),
             ..default()
-        })
-        .insert(Collider::cuboid(1.0, 1.0, 1.0))
-        .insert(RigidBody::Fixed)
-        .insert(Transform::from_xyz(4.0, 1.0, 4.0));
+        },
+        Collider::cuboid(1.0, 2.0, 1.0),
+        RigidBody::Fixed,
+    ));
 }
 
 pub fn manage_cursor(

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -374,11 +374,13 @@ pub fn fps_controller_move(
                     controller.player_height = capsule.segment.b.y;
                     let crouch_height = controller.crouch_height;
                     let uncrouch_height = controller.uncrouch_height;
+                    let height_dist = uncrouch_height - controller.player_height;
+                    let smooth = ((height_dist - (uncrouch_height - crouch_height) * 0.5) / ((uncrouch_height - crouch_height) * 0.5)).copysign(-1.0);
 
                     if input.crouch {
-                        controller.player_height -= dt * controller.crouch_speed; 
+                        controller.player_height -= dt * controller.crouch_speed + smooth * (controller.crouch_speed - 0.4) * dt; 
                     } else {
-                        controller.player_height += dt * controller.uncrouch_speed;
+                        controller.player_height += dt * controller.uncrouch_speed + smooth * (controller.uncrouch_speed - 0.4) * dt;
                     }
 
                     controller.player_height = controller.player_height.clamp(crouch_height, uncrouch_height);

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -375,7 +375,7 @@ pub fn fps_controller_move(
                     let crouch_height = controller.crouch_height;
                     let uncrouch_height = controller.uncrouch_height;
                     let height_dist = uncrouch_height - controller.player_height;
-                    let smooth = ((height_dist - (uncrouch_height - crouch_height) * 0.5) / ((uncrouch_height - crouch_height) * 0.5)).copysign(-1.0);
+                    let smooth = ((height_dist - (uncrouch_height - crouch_height) * 0.5) / ((uncrouch_height - crouch_height) * 0.5)).copysign(-1.0); // This is effectively to decelerate the movement at either end of the crouch, much like a "smoothstep"
 
                     if input.crouch {
                         controller.player_height -= dt * controller.crouch_speed + smooth * (controller.crouch_speed - 0.4) * dt; 


### PR DESCRIPTION
- Add crouching
- Crouching prevents controller from falling off a ledge
- Use system sets to force defined update of all fps systems
- Added a new feature "friction_normal_cutoff" that may make surfing possible 👀
- Saner defaults, for example max air speed was lower than running and sprinting
- Make example use zero friction and restitution since we handle that in controller
- Change colors of example scene to be better