### PR TITLE
Add gamepad support

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,6 +1,7 @@
 use std::f32::consts::*;
+use std::hash::Hash;
 
-use bevy::{input::mouse::MouseMotion, math::Vec3Swizzles, prelude::*};
+use bevy::{input::mouse::MouseMotion, prelude::*};
 use bevy_rapier3d::prelude::*;
 
 /// Manages the FPS controllers. Executes in `PreUpdate`, after bevy's internal
@@ -34,6 +35,7 @@ impl Plugin for FpsControllerPlugin {
             PreUpdate,
             (
                 fps_controller_input,
+                fps_controller_gamepad_input,
                 fps_controller_look,
                 fps_controller_move,
                 fps_controller_render,
@@ -113,7 +115,7 @@ pub struct FpsController {
     pub yaw: f32,
     pub ground_tick: u8,
     pub stop_speed: f32,
-    pub sensitivity: f32,
+    pub mouse_sensitivity: f32,
     pub enable_input: bool,
     pub step_offset: f32,
     pub key_forward: KeyCode,
@@ -126,6 +128,17 @@ pub struct FpsController {
     pub key_jump: KeyCode,
     pub key_fly: KeyCode,
     pub key_crouch: KeyCode,
+    pub pad_move_x: GamepadAxisType,
+    pub pad_move_y: GamepadAxisType,
+    pub pad_look_x: GamepadAxisType,
+    pub pad_look_y: GamepadAxisType,
+    pub pad_fly_up: GamepadButtonType,
+    pub pad_fly_down: GamepadButtonType,
+    pub pad_jump: GamepadButtonType,
+    pub pad_sprint: GamepadButtonType,
+    pub pad_fly: GamepadButtonType,
+    pub pad_crouch: GamepadButtonType,
+    pub pad_sensitivity: f32,
 }
 
 impl Default for FpsController {
@@ -171,7 +184,18 @@ impl Default for FpsController {
             key_jump: KeyCode::Space,
             key_fly: KeyCode::KeyF,
             key_crouch: KeyCode::ControlLeft,
-            sensitivity: 0.001,
+            mouse_sensitivity: 0.001,
+            pad_move_x: GamepadAxisType::LeftStickX,
+            pad_move_y: GamepadAxisType::LeftStickY,
+            pad_look_x: GamepadAxisType::RightStickX,
+            pad_look_y: GamepadAxisType::RightStickY,
+            pad_fly_up: GamepadButtonType::DPadUp,
+            pad_fly_down: GamepadButtonType::DPadDown,
+            pad_jump: GamepadButtonType::South,
+            pad_sprint: GamepadButtonType::LeftThumb,
+            pad_fly: GamepadButtonType::RightThumb,
+            pad_crouch: GamepadButtonType::East,
+            pad_sensitivity: 0.025,
         }
     }
 }
@@ -199,7 +223,7 @@ pub fn fps_controller_input(
         for mouse_event in mouse_events.read() {
             mouse_delta += mouse_event.delta;
         }
-        mouse_delta *= controller.sensitivity;
+        mouse_delta *= controller.mouse_sensitivity;
 
         input.pitch = (input.pitch - mouse_delta.y)
             .clamp(-FRAC_PI_2 + ANGLE_EPSILON, FRAC_PI_2 - ANGLE_EPSILON);
@@ -209,14 +233,59 @@ pub fn fps_controller_input(
         }
 
         input.movement = Vec3::new(
-            get_axis(&key_input, controller.key_right, controller.key_left),
-            get_axis(&key_input, controller.key_up, controller.key_down),
-            get_axis(&key_input, controller.key_forward, controller.key_back),
+            to_axis(&key_input, controller.key_right, controller.key_left),
+            to_axis(&key_input, controller.key_up, controller.key_down),
+            to_axis(&key_input, controller.key_forward, controller.key_back),
         );
         input.sprint = key_input.pressed(controller.key_sprint);
         input.jump = key_input.pressed(controller.key_jump);
         input.fly = key_input.just_pressed(controller.key_fly);
         input.crouch = key_input.pressed(controller.key_crouch);
+    }
+}
+
+pub fn fps_controller_gamepad_input(
+    gamepads: Res<Gamepads>,
+    axis_input: Res<Axis<GamepadAxis>>,
+    button_input: Res<ButtonInput<GamepadButton>>,
+    mut query: Query<(&FpsController, &mut FpsControllerInput)>,
+) {
+    for gamepad in gamepads.iter() {
+        // Helper functions to get axis and button values
+        let axis = |axis_type| {
+            axis_input
+                .get(GamepadAxis::new(gamepad, axis_type))
+                .unwrap()
+        };
+        let button = |button_type| GamepadButton::new(gamepad, button_type);
+
+        for (controller, mut input) in query.iter_mut() {
+            if !controller.enable_input {
+                continue;
+            }
+
+            let move_vec = Vec2::new(axis(controller.pad_move_x), axis(controller.pad_move_y));
+            let look_vec = Vec2::new(axis(controller.pad_look_x), axis(controller.pad_look_y))
+                * controller.pad_sensitivity;
+
+            input.pitch = (input.pitch + look_vec.y)
+                .clamp(-FRAC_PI_2 + ANGLE_EPSILON, FRAC_PI_2 - ANGLE_EPSILON);
+            input.yaw -= look_vec.x;
+            if input.yaw.abs() > PI {
+                input.yaw = input.yaw.rem_euclid(TAU);
+            }
+
+            let vertical_axis = to_axis(
+                &button_input,
+                button(controller.pad_fly_up),
+                button(controller.pad_fly_down),
+            );
+            input.movement = Vec3::new(move_vec.x, vertical_axis, move_vec.y);
+            input.sprint = button_input.pressed(button(controller.pad_sprint));
+            input.jump = button_input.pressed(button(controller.pad_jump));
+            input.fly = button_input.just_pressed(button(controller.pad_fly));
+            input.crouch = button_input.pressed(button(controller.pad_crouch));
+        }
     }
 }
 
@@ -516,16 +585,9 @@ fn acceleration(
     wish_direction * acceleration_speed
 }
 
-fn get_pressed(key_input: &Res<ButtonInput<KeyCode>>, key: KeyCode) -> f32 {
-    if key_input.pressed(key) {
-        1.0
-    } else {
-        0.0
-    }
-}
-
-fn get_axis(key_input: &Res<ButtonInput<KeyCode>>, key_pos: KeyCode, key_neg: KeyCode) -> f32 {
-    get_pressed(key_input, key_pos) - get_pressed(key_input, key_neg)
+/// Converts two button inputs into an f32 with a range of [-1, 1]
+fn to_axis<T: Copy + Eq + Send + Sync + Hash>(input: &Res<ButtonInput<T>>, pos: T, neg: T) -> f32 {
+    input.pressed(pos) as u8 as f32 - input.pressed(neg) as u8 as f32
 }
 
 // ██████╗ ███████╗███╗   ██╗██████╗ ███████╗██████╗


### PR DESCRIPTION
The controller doesn't currently support gamepads. This PR aims to change that!

Currently, keyboard input is broken as the gamepad is overriding the values in `FpsControllerInput`.  
There are two ways of solving this:
1. Both input methods need to reach consensus. For example, pressing W on your keyboard and moving the left stick to the left will cause the player to move forward and left.
2. The game should automatically switch between the two input methods (depending on which one received the most recent input)

I'm not sure which solution is best, so any input is welcome! (pun not intended)