### PR TITLE
Add `avian3d` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ checksum = "f548ad2c4031f2902e3edc1f29c29e835829437de49562d8eb5dc5584d3a1043"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -287,6 +287,39 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "avian3d"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b563e53203ce50ce39c221a7e0b1f73b8fc2b4aa65439b436700c4ee1e85547a"
+dependencies = [
+ "avian_derive",
+ "bevy",
+ "bevy_heavy",
+ "bevy_math",
+ "bevy_transform_interpolation",
+ "bitflags 2.6.0",
+ "derive_more",
+ "fxhash",
+ "indexmap",
+ "itertools",
+ "nalgebra",
+ "parry3d",
+ "parry3d-f64",
+]
+
+[[package]]
+name = "avian_derive"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7a3e79be90cc09d87a43e1d9bf4f41c896f97cbd7d4fe4c3b79749106d285"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
 
 [[package]]
 name = "base64"
@@ -419,7 +452,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -505,7 +538,7 @@ checksum = "e141b7eda52a23bb88740b37a291e26394524cb9ee3b034c7014669671fc2bb5"
 dependencies = [
  "bevy_macro_utils",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -556,7 +589,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -573,6 +606,7 @@ dependencies = [
 name = "bevy_fps_controller"
 version = "0.15.0"
 dependencies = [
+ "avian3d",
  "bevy",
  "bevy_rapier3d",
 ]
@@ -625,7 +659,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -658,6 +692,16 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+]
+
+[[package]]
+name = "bevy_heavy"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f85619a206875db57b0213dc5242b51f1be748663cd5f8f99f78d2a6a108dabf"
+dependencies = [
+ "bevy_math",
+ "bevy_reflect",
 ]
 
 [[package]]
@@ -780,7 +824,7 @@ checksum = "3954dbb56a66a6c09c783e767f6ceca0dc0492c22e536e2aeaefb5545eac33c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
  "toml_edit",
 ]
 
@@ -935,7 +979,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
  "uuid",
 ]
 
@@ -995,7 +1039,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1071,7 +1115,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1145,6 +1189,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_transform_interpolation"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fcad6974fb74cab07425c4f3d3af78876966b4525c3aec5c0d56ae8511a946a"
+dependencies = [
+ "bevy",
+]
+
+[[package]]
 name = "bevy_ui"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,7 +1253,7 @@ checksum = "3dfd8d4a525b8f04f85863e45ccad3e922d4c11ed4a8d54f7f62a40bf83fb90f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1271,7 +1324,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1389,7 +1442,7 @@ checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1803,7 +1856,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
  "unicode-xid",
 ]
 
@@ -1893,7 +1946,7 @@ checksum = "f97b51c5cc57ef7c5f7a0c57c250251c49ee4c28f819f87ac32f4aceabc36792"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2057,7 +2110,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2098,6 +2151,15 @@ dependencies = [
  "futures-io",
  "parking",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -2218,7 +2280,7 @@ dependencies = [
  "inflections",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2757,7 +2819,7 @@ checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2887,7 +2949,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2938,7 +3000,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3271,6 +3333,34 @@ dependencies = [
  "num-derive",
  "num-traits",
  "ordered-float",
+ "rayon",
+ "rstar",
+ "rustc-hash 2.1.0",
+ "simba",
+ "slab",
+ "smallvec",
+ "spade",
+ "thiserror",
+]
+
+[[package]]
+name = "parry3d-f64"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc818b4a4851b7005b6042f6c16b93f7f4e37d17ec459ded6d0885dad61b82cb"
+dependencies = [
+ "approx",
+ "arrayvec",
+ "bitflags 2.6.0",
+ "downcast-rs",
+ "either",
+ "ena",
+ "log",
+ "nalgebra",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "rayon",
  "rstar",
  "rustc-hash 2.1.0",
  "simba",
@@ -3321,7 +3411,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3406,7 +3496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3416,6 +3506,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -3795,7 +3909,7 @@ checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3945,6 +4059,16 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
@@ -4015,7 +4139,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4088,7 +4212,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4315,7 +4439,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
  "wasm-bindgen-shared",
 ]
 
@@ -4350,7 +4474,7 @@ checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4601,7 +4725,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4612,7 +4736,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4623,7 +4747,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4634,7 +4758,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5010,5 +5134,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,20 @@ description = "Bevy plugin that adds a Source engine inspired FPS movement contr
 
 [dependencies]
 bevy = "0.15"
-bevy_rapier3d = "0.28"
+bevy_rapier3d = { version = "0.28", optional = true }
+avian3d = { version = "0.2.0", optional = true }
+
+[features]
+default = ["avian"]
+avian = ["dep:avian3d"]
+rapier = ["dep:bevy_rapier3d"]
 
 [[example]]
-name = "minimal"
-path = "examples/minimal.rs"
+name = "minimal_avian"
+path = "examples/minimal_avian.rs"
+required-features = ["avian"]
+
+[[example]]
+name = "minimal_rapier"
+path = "examples/minimal_rapier.rs"
+required-features = ["rapier"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ bevy_rapier3d = { version = "0.28", optional = true }
 avian3d = { version = "0.2.0", optional = true }
 
 [features]
-default = ["avian"]
+default = []
 avian = ["dep:avian3d"]
 rapier = ["dep:bevy_rapier3d"]
 

--- a/examples/minimal_avian.rs
+++ b/examples/minimal_avian.rs
@@ -1,0 +1,219 @@
+use std::f32::consts::TAU;
+
+use avian3d::prelude::*;
+use bevy::{
+    gltf::{Gltf, GltfMesh, GltfNode},
+    math::Vec3Swizzles,
+    prelude::*,
+    render::camera::Exposure,
+    window::CursorGrabMode,
+};
+
+use bevy_fps_controller::controller::*;
+
+const SPAWN_POINT: Vec3 = Vec3::new(0.0, 1.625, 0.0);
+
+fn main() {
+    App::new()
+        .insert_resource(AmbientLight {
+            color: Color::WHITE,
+            brightness: 10000.0,
+        })
+        .insert_resource(ClearColor(Color::linear_rgb(0.83, 0.96, 0.96)))
+        .add_plugins(DefaultPlugins)
+        .add_plugins(PhysicsPlugins::default())
+        // .add_plugins(PhysicsDebugPlugin::default())
+        .add_plugins(FpsControllerPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(
+            Update,
+            (manage_cursor, scene_colliders, display_text, respawn),
+        )
+        .run();
+}
+
+fn setup(mut commands: Commands, mut window: Query<&mut Window>, assets: Res<AssetServer>) {
+    let mut window = window.single_mut();
+    window.title = String::from("Minimal FPS Controller Example");
+
+    commands.spawn((
+        DirectionalLight {
+            illuminance: light_consts::lux::FULL_DAYLIGHT,
+            shadows_enabled: true,
+            ..default()
+        },
+        Transform::from_xyz(4.0, 7.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+
+    // Note that we have two entities for the player
+    // One is a "logical" player that handles the physics computation and collision
+    // The other is a "render" player that is what is displayed to the user
+    // This distinction is useful for later on if you want to add multiplayer,
+    // where often time these two ideas are not exactly synced up
+    let height = 3.0;
+    let logical_entity = commands
+        .spawn((
+            Collider::cylinder(0.5, height),
+            // A capsule can be used but is NOT recommended
+            // If you use it, you have to make sure each segment point is
+            // equidistant from the translation of the player transform
+            // Collider::capsule(0.5, height),
+            Friction {
+                dynamic_coefficient: 0.0,
+                static_coefficient: 0.0,
+                combine_rule: CoefficientCombine::Min,
+            },
+            Restitution {
+                coefficient: 0.0,
+                combine_rule: CoefficientCombine::Min,
+            },
+            LinearVelocity::ZERO,
+            RigidBody::Dynamic,
+            Sleeping,
+            LockedAxes::ROTATION_LOCKED,
+            Mass(1.0),
+            GravityScale(0.0),
+            Transform::from_translation(SPAWN_POINT),
+            LogicalPlayer,
+            FpsControllerInput {
+                pitch: -TAU / 12.0,
+                yaw: TAU * 5.0 / 8.0,
+                ..default()
+            },
+            FpsController {
+                air_acceleration: 80.0,
+                ..default()
+            },
+        ))
+        .insert(CameraConfig {
+            height_offset: -0.5,
+        })
+        .id();
+
+    commands.spawn((
+        Camera3d::default(),
+        Projection::Perspective(PerspectiveProjection {
+            fov: TAU / 5.0,
+            ..default()
+        }),
+        Exposure::SUNLIGHT,
+        RenderPlayer { logical_entity },
+    ));
+
+    commands.insert_resource(MainScene {
+        handle: assets.load("playground.glb"),
+        is_loaded: false,
+    });
+
+    commands.spawn((
+        Text(String::from("")),
+        TextFont {
+            font: assets.load("fira_mono.ttf"),
+            font_size: 24.0,
+            ..default()
+        },
+        TextColor(Color::BLACK),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(5.0),
+            left: Val::Px(5.0),
+            ..default()
+        },
+    ));
+}
+
+fn respawn(mut query: Query<(&mut Transform, &mut LinearVelocity)>) {
+    for (mut transform, mut velocity) in &mut query {
+        if transform.translation.y > -50.0 {
+            continue;
+        }
+
+        velocity.0 = Vec3::ZERO;
+        transform.translation = SPAWN_POINT;
+    }
+}
+
+#[derive(Resource)]
+struct MainScene {
+    handle: Handle<Gltf>,
+    is_loaded: bool,
+}
+
+fn scene_colliders(
+    mut commands: Commands,
+    mut main_scene: ResMut<MainScene>,
+    gltf_assets: Res<Assets<Gltf>>,
+    gltf_mesh_assets: Res<Assets<GltfMesh>>,
+    gltf_node_assets: Res<Assets<GltfNode>>,
+    mesh_assets: Res<Assets<Mesh>>,
+) {
+    if main_scene.is_loaded {
+        return;
+    }
+
+    let gltf = gltf_assets.get(&main_scene.handle);
+
+    if let Some(gltf) = gltf {
+        let scene = gltf.scenes.first().unwrap().clone();
+        commands.spawn(SceneRoot(scene));
+        for node in &gltf.nodes {
+            let node = gltf_node_assets.get(node).unwrap();
+            if let Some(gltf_mesh) = node.mesh.clone() {
+                let gltf_mesh = gltf_mesh_assets.get(&gltf_mesh).unwrap();
+                for mesh_primitive in &gltf_mesh.primitives {
+                    let mesh = mesh_assets.get(&mesh_primitive.mesh).unwrap();
+                    commands.spawn((
+                        Collider::trimesh_from_mesh(mesh).unwrap(),
+                        RigidBody::Static,
+                        node.transform,
+                    ));
+                }
+            }
+        }
+        main_scene.is_loaded = true;
+    }
+}
+
+fn manage_cursor(
+    btn: Res<ButtonInput<MouseButton>>,
+    key: Res<ButtonInput<KeyCode>>,
+    mut window_query: Query<&mut Window>,
+    mut controller_query: Query<&mut FpsController>,
+) {
+    for mut window in &mut window_query {
+        if btn.just_pressed(MouseButton::Left) {
+            window.cursor_options.grab_mode = CursorGrabMode::Locked;
+            window.cursor_options.visible = false;
+            for mut controller in &mut controller_query {
+                controller.enable_input = true;
+            }
+        }
+        if key.just_pressed(KeyCode::Escape) {
+            window.cursor_options.grab_mode = CursorGrabMode::None;
+            window.cursor_options.visible = true;
+            for mut controller in &mut controller_query {
+                controller.enable_input = false;
+            }
+        }
+    }
+}
+
+fn display_text(
+    mut controller_query: Query<(&Transform, &LinearVelocity), With<LogicalPlayer>>,
+    mut text_query: Query<&mut Text>,
+) {
+    for (transform, velocity) in &mut controller_query {
+        for mut text in &mut text_query {
+            text.0 = format!(
+                "vel: {:.2}, {:.2}, {:.2}\npos: {:.2}, {:.2}, {:.2}\nspd: {:.2}",
+                velocity.0.x,
+                velocity.0.y,
+                velocity.0.z,
+                transform.translation.x,
+                transform.translation.y,
+                transform.translation.z,
+                velocity.0.xz().length()
+            );
+        }
+    }
+}

--- a/examples/minimal_rapier.rs
+++ b/examples/minimal_rapier.rs
@@ -120,7 +120,7 @@ fn setup(mut commands: Commands, mut window: Query<&mut Window>, assets: Res<Ass
             top: Val::Px(5.0),
             left: Val::Px(5.0),
             ..default()
-        }
+        },
     ));
 }
 

--- a/src/controller_avian.rs
+++ b/src/controller_avian.rs
@@ -1,0 +1,594 @@
+use std::f32::consts::*;
+
+use avian3d::{
+    parry::{math::Point, shape::SharedShape},
+    prelude::*,
+};
+use bevy::{input::mouse::MouseMotion, math::Vec3Swizzles, prelude::*};
+
+/// Manages the FPS controllers. Executes in `PreUpdate`, after bevy's internal
+/// input processing is finished.
+///
+/// If you need a system in `PreUpdate` to execute after FPS Controller's systems,
+/// Do it like so:
+///
+/// ```
+/// # use bevy::prelude::*;
+///
+/// struct MyPlugin;
+/// impl Plugin for MyPlugin {
+///     fn build(&self, app: &mut App) {
+///         app.add_systems(
+///             PreUpdate,
+///             my_system.after(bevy_fps_controller::controller::fps_controller_render),
+///         );
+///     }
+/// }
+///
+/// fn my_system() { }
+/// ```
+pub struct FpsControllerPlugin;
+
+impl Plugin for FpsControllerPlugin {
+    fn build(&self, app: &mut App) {
+        use bevy::input::{gamepad, keyboard, mouse, touch};
+
+        app.add_systems(
+            PreUpdate,
+            (
+                fps_controller_input,
+                fps_controller_look,
+                fps_controller_move,
+                fps_controller_render,
+            )
+                .chain()
+                .after(mouse::mouse_button_input_system)
+                .after(keyboard::keyboard_input_system)
+                .after(gamepad::gamepad_event_processing_system)
+                .after(gamepad::gamepad_connection_system)
+                .after(touch::touch_screen_input_system),
+        );
+    }
+}
+
+#[derive(PartialEq)]
+pub enum MoveMode {
+    Noclip,
+    Ground,
+}
+
+#[derive(Component)]
+pub struct LogicalPlayer;
+
+#[derive(Component)]
+pub struct RenderPlayer {
+    pub logical_entity: Entity,
+}
+
+#[derive(Component)]
+pub struct CameraConfig {
+    pub height_offset: f32,
+}
+
+#[derive(Component, Default)]
+pub struct FpsControllerInput {
+    pub fly: bool,
+    pub sprint: bool,
+    pub jump: bool,
+    pub crouch: bool,
+    pub pitch: f32,
+    pub yaw: f32,
+    pub movement: Vec3,
+}
+
+#[derive(Component)]
+pub struct FpsController {
+    pub move_mode: MoveMode,
+    pub radius: f32,
+    pub gravity: f32,
+    pub walk_speed: f32,
+    pub run_speed: f32,
+    pub forward_speed: f32,
+    pub side_speed: f32,
+    pub air_speed_cap: f32,
+    pub air_acceleration: f32,
+    pub max_air_speed: f32,
+    pub acceleration: f32,
+    pub friction: f32,
+    /// If the dot product (alignment) of the normal of the surface and the upward vector,
+    /// which is a value from [-1, 1], is greater than this value, ground movement is applied
+    pub traction_normal_cutoff: f32,
+    pub friction_speed_cutoff: f32,
+    pub jump_speed: f32,
+    pub fly_speed: f32,
+    pub crouched_speed: f32,
+    pub crouch_speed: f32,
+    pub uncrouch_speed: f32,
+    pub height: f32,
+    pub upright_height: f32,
+    pub crouch_height: f32,
+    pub fast_fly_speed: f32,
+    pub fly_friction: f32,
+    pub pitch: f32,
+    pub yaw: f32,
+    pub ground_tick: u8,
+    pub stop_speed: f32,
+    pub sensitivity: f32,
+    pub enable_input: bool,
+    pub step_offset: f32,
+    pub key_forward: KeyCode,
+    pub key_back: KeyCode,
+    pub key_left: KeyCode,
+    pub key_right: KeyCode,
+    pub key_up: KeyCode,
+    pub key_down: KeyCode,
+    pub key_sprint: KeyCode,
+    pub key_jump: KeyCode,
+    pub key_fly: KeyCode,
+    pub key_crouch: KeyCode,
+}
+
+impl Default for FpsController {
+    fn default() -> Self {
+        Self {
+            move_mode: MoveMode::Ground,
+            radius: 0.5,
+            fly_speed: 10.0,
+            fast_fly_speed: 30.0,
+            gravity: 23.0,
+            walk_speed: 9.0,
+            run_speed: 14.0,
+            forward_speed: 30.0,
+            side_speed: 30.0,
+            air_speed_cap: 2.0,
+            air_acceleration: 20.0,
+            max_air_speed: 15.0,
+            crouched_speed: 5.0,
+            crouch_speed: 6.0,
+            uncrouch_speed: 8.0,
+            height: 3.0,
+            upright_height: 3.0,
+            crouch_height: 1.5,
+            acceleration: 10.0,
+            friction: 10.0,
+            traction_normal_cutoff: 0.7,
+            friction_speed_cutoff: 0.1,
+            fly_friction: 0.5,
+            pitch: 0.0,
+            yaw: 0.0,
+            ground_tick: 0,
+            stop_speed: 1.0,
+            jump_speed: 8.5,
+            step_offset: 0.25,
+            enable_input: true,
+            key_forward: KeyCode::KeyW,
+            key_back: KeyCode::KeyS,
+            key_left: KeyCode::KeyA,
+            key_right: KeyCode::KeyD,
+            key_up: KeyCode::KeyQ,
+            key_down: KeyCode::KeyE,
+            key_sprint: KeyCode::ShiftLeft,
+            key_jump: KeyCode::Space,
+            key_fly: KeyCode::KeyF,
+            key_crouch: KeyCode::ControlLeft,
+            sensitivity: 0.001,
+        }
+    }
+}
+
+// ██╗      ██████╗  ██████╗ ██╗ ██████╗
+// ██║     ██╔═══██╗██╔════╝ ██║██╔════╝
+// ██║     ██║   ██║██║  ███╗██║██║
+// ██║     ██║   ██║██║   ██║██║██║
+// ███████╗╚██████╔╝╚██████╔╝██║╚██████╗
+// ╚══════╝ ╚═════╝  ╚═════╝ ╚═╝ ╚═════╝
+
+// Used as padding by camera pitching (up/down) to avoid spooky math problems
+const ANGLE_EPSILON: f32 = 0.001953125;
+
+// If the distance to the ground is less than this value, the player is considered grounded
+const GROUNDED_DISTANCE: f32 = 0.125;
+
+const SLIGHT_SCALE_DOWN: f32 = 0.9375;
+
+pub fn fps_controller_input(
+    key_input: Res<ButtonInput<KeyCode>>,
+    mut mouse_events: EventReader<MouseMotion>,
+    mut query: Query<(&FpsController, &mut FpsControllerInput)>,
+) {
+    for (controller, mut input) in query
+        .iter_mut()
+        .filter(|(controller, _)| controller.enable_input)
+    {
+        let mut mouse_delta = Vec2::ZERO;
+        for mouse_event in mouse_events.read() {
+            mouse_delta += mouse_event.delta;
+        }
+        mouse_delta *= controller.sensitivity;
+
+        input.pitch = (input.pitch - mouse_delta.y)
+            .clamp(-FRAC_PI_2 + ANGLE_EPSILON, FRAC_PI_2 - ANGLE_EPSILON);
+        input.yaw -= mouse_delta.x;
+        if input.yaw.abs() > PI {
+            input.yaw = input.yaw.rem_euclid(TAU);
+        }
+
+        input.movement = Vec3::new(
+            get_axis(&key_input, controller.key_right, controller.key_left),
+            get_axis(&key_input, controller.key_up, controller.key_down),
+            get_axis(&key_input, controller.key_forward, controller.key_back),
+        );
+        input.sprint = key_input.pressed(controller.key_sprint);
+        input.jump = key_input.pressed(controller.key_jump);
+        input.fly = key_input.just_pressed(controller.key_fly);
+        input.crouch = key_input.pressed(controller.key_crouch);
+    }
+}
+
+pub fn fps_controller_look(mut query: Query<(&mut FpsController, &FpsControllerInput)>) {
+    for (mut controller, input) in query.iter_mut() {
+        controller.pitch = input.pitch;
+        controller.yaw = input.yaw;
+    }
+}
+
+pub fn fps_controller_move(
+    time: Res<Time>,
+    spatial_query_pipeline: Res<SpatialQueryPipeline>,
+    mut query: Query<
+        (
+            Entity,
+            &FpsControllerInput,
+            &mut FpsController,
+            &mut Collider,
+            &mut Transform,
+            &mut LinearVelocity,
+        ),
+        With<LogicalPlayer>,
+    >,
+) {
+    let dt = time.delta_secs();
+
+    for (entity, input, mut controller, mut collider, mut transform, mut velocity) in
+        query.iter_mut()
+    {
+        if input.fly {
+            controller.move_mode = match controller.move_mode {
+                MoveMode::Noclip => MoveMode::Ground,
+                MoveMode::Ground => MoveMode::Noclip,
+            }
+        }
+
+        match controller.move_mode {
+            MoveMode::Noclip => {
+                if input.movement == Vec3::ZERO {
+                    let friction = controller.fly_friction.clamp(0.0, 1.0);
+                    velocity.0 *= 1.0 - friction;
+                    if velocity.length_squared() < f32::EPSILON {
+                        velocity.0 = Vec3::ZERO;
+                    }
+                } else {
+                    let fly_speed = if input.sprint {
+                        controller.fast_fly_speed
+                    } else {
+                        controller.fly_speed
+                    };
+                    let mut move_to_world =
+                        Mat3::from_euler(EulerRot::YXZ, input.yaw, input.pitch, 0.0);
+                    move_to_world.z_axis *= -1.0; // Forward is -Z
+                    move_to_world.y_axis = Vec3::Y; // Vertical movement aligned with world up
+                    velocity.0 = move_to_world * input.movement * fly_speed;
+                }
+            }
+            MoveMode::Ground => {
+                let speeds = Vec3::new(controller.side_speed, 0.0, controller.forward_speed);
+                let mut move_to_world = Mat3::from_axis_angle(Vec3::Y, input.yaw);
+                move_to_world.z_axis *= -1.0; // Forward is -Z
+                let mut wish_direction = move_to_world * (input.movement * speeds);
+                let mut wish_speed = wish_direction.length();
+                if wish_speed > f32::EPSILON {
+                    // Avoid division by zero
+                    wish_direction /= wish_speed; // Effectively normalize, avoid length computation twice
+                }
+                let max_speed = if input.crouch {
+                    controller.crouched_speed
+                } else if input.sprint {
+                    controller.run_speed
+                } else {
+                    controller.walk_speed
+                };
+                wish_speed = f32::min(wish_speed, max_speed);
+
+                // Shape cast downwards to find ground
+                // Better than a ray cast as it handles when you are near the edge of a surface
+                let filter = SpatialQueryFilter::default().with_excluded_entities([entity]);
+                if let Some(hit) = spatial_query_pipeline.cast_shape(
+                    // Consider when the controller is right up against a wall
+                    // We do not want the shape cast to detect it,
+                    // so provide a slightly smaller collider in the XZ plane
+                    &scaled_collider_laterally(&collider, SLIGHT_SCALE_DOWN),
+                    transform.translation,
+                    transform.rotation,
+                    -Dir3::Y,
+                    &ShapeCastConfig::from_max_distance(GROUNDED_DISTANCE),
+                    &filter,
+                ) {
+                    let has_traction =
+                        Vec3::dot(hit.normal1, Vec3::Y) > controller.traction_normal_cutoff;
+
+                    // Only apply friction after at least one tick, allows b-hopping without losing speed
+                    if controller.ground_tick >= 1 && has_traction {
+                        let lateral_speed = velocity.0.xz().length();
+                        if lateral_speed > controller.friction_speed_cutoff {
+                            let control = f32::max(lateral_speed, controller.stop_speed);
+                            let drop = control * controller.friction * dt;
+                            let new_speed = f32::max((lateral_speed - drop) / lateral_speed, 0.0);
+                            velocity.0.x *= new_speed;
+                            velocity.0.z *= new_speed;
+                        } else {
+                            velocity.0 = Vec3::ZERO;
+                        }
+                        if controller.ground_tick == 1 {
+                            velocity.0.y = -hit.distance;
+                        }
+                    }
+
+                    let mut add = acceleration(
+                        wish_direction,
+                        wish_speed,
+                        controller.acceleration,
+                        velocity.0,
+                        dt,
+                    );
+                    if !has_traction {
+                        add.y -= controller.gravity * dt;
+                    }
+                    velocity.0 += add;
+
+                    if has_traction {
+                        let linear_velocity = velocity.0;
+                        velocity.0 -= Vec3::dot(linear_velocity, hit.normal1) * hit.normal1;
+
+                        if input.jump {
+                            velocity.0.y = controller.jump_speed;
+                        }
+                    }
+
+                    // Increment ground tick but cap at max value
+                    controller.ground_tick = controller.ground_tick.saturating_add(1);
+                } else {
+                    controller.ground_tick = 0;
+                    wish_speed = f32::min(wish_speed, controller.air_speed_cap);
+
+                    let mut add = acceleration(
+                        wish_direction,
+                        wish_speed,
+                        controller.air_acceleration,
+                        velocity.0,
+                        dt,
+                    );
+                    add.y = -controller.gravity * dt;
+                    velocity.0 += add;
+
+                    let air_speed = velocity.xz().length();
+                    if air_speed > controller.max_air_speed {
+                        let ratio = controller.max_air_speed / air_speed;
+                        velocity.0.x *= ratio;
+                        velocity.0.z *= ratio;
+                    }
+                };
+
+                /* Crouching */
+
+                let crouch_height = controller.crouch_height;
+                let upright_height = controller.upright_height;
+
+                let crouch_speed = if input.crouch {
+                    -controller.crouch_speed
+                } else {
+                    controller.uncrouch_speed
+                };
+                controller.height += dt * crouch_speed;
+                controller.height = controller.height.clamp(crouch_height, upright_height);
+
+                if let Some(capsule) = collider.shape().as_capsule() {
+                    let radius = capsule.radius;
+                    let half = Point::from(Vec3::Y * (controller.height * 0.5 - radius));
+                    collider.set_shape(SharedShape::capsule(-half, half, radius));
+                } else if let Some(cylinder) = collider.shape().as_cylinder() {
+                    let radius = cylinder.radius;
+                    collider.set_shape(SharedShape::cylinder(controller.height * 0.5, radius));
+                } else {
+                    panic!("Controller must use a cylinder or capsule collider")
+                }
+
+                // Step offset really only works best for cylinders
+                // For capsules the player has to practically teleported to fully step up
+                if collider.shape().as_cylinder().is_some()
+                    && controller.step_offset > f32::EPSILON
+                    && controller.ground_tick >= 1
+                {
+                    // Try putting the player forward, but instead lifted upward by the step offset
+                    // If we can find a surface below us, we can adjust our position to be on top of it
+                    let future_position = transform.translation + velocity.0 * dt;
+                    let future_position_lifted = future_position + Vec3::Y * controller.step_offset;
+                    if let Some(hit) = spatial_query_pipeline.cast_shape(
+                        &collider,
+                        future_position_lifted,
+                        transform.rotation,
+                        Dir3::new_unchecked(-Vec3::Y),
+                        &ShapeCastConfig::from_max_distance(
+                            controller.step_offset * SLIGHT_SCALE_DOWN,
+                        ),
+                        &filter,
+                    ) {
+                        let has_traction_on_ledge =
+                            Vec3::dot(hit.normal1, Vec3::Y) > controller.traction_normal_cutoff;
+                        if has_traction_on_ledge {
+                            transform.translation.y += controller.step_offset - hit.distance;
+                        }
+                    }
+                }
+
+                // Prevent falling off ledges
+                if controller.ground_tick >= 1 && input.crouch && !input.jump {
+                    for _ in 0..2 {
+                        // Find the component of our velocity that is overhanging and subtract it off
+                        let overhang = overhang_component(
+                            entity,
+                            &collider,
+                            transform.as_ref(),
+                            &spatial_query_pipeline,
+                            velocity.0,
+                            dt,
+                        );
+                        if let Some(overhang) = overhang {
+                            velocity.0 -= overhang;
+                        }
+                    }
+                    // If we are still overhanging consider unsolvable and freeze
+                    if overhang_component(
+                        entity,
+                        &collider,
+                        transform.as_ref(),
+                        &spatial_query_pipeline,
+                        velocity.0,
+                        dt,
+                    )
+                    .is_some()
+                    {
+                        velocity.0 = Vec3::ZERO;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Returns the offset that puts a point at the center of the player transform to the bottom of the collider.
+/// Needed for when we want to originate something at the foot of the player.
+fn collider_y_offset(collider: &Collider) -> Vec3 {
+    Vec3::Y
+        * if let Some(cylinder) = collider.shape().as_cylinder() {
+            cylinder.half_height
+        } else if let Some(capsule) = collider.shape().as_capsule() {
+            capsule.half_height() + capsule.radius
+        } else {
+            panic!("Controller must use a cylinder or capsule collider")
+        }
+}
+
+/// Return a collider that is scaled laterally (XZ plane) but not vertically (Y axis).
+fn scaled_collider_laterally(collider: &Collider, scale: f32) -> Collider {
+    if let Some(cylinder) = collider.shape().as_cylinder() {
+        let new_cylinder = Collider::cylinder(cylinder.radius * scale, cylinder.half_height * 2.0);
+        new_cylinder
+    } else if let Some(capsule) = collider.shape().as_capsule() {
+        let new_capsule = Collider::capsule(capsule.radius * scale, capsule.segment.length());
+        new_capsule
+    } else {
+        panic!("Controller must use a cylinder or capsule collider")
+    }
+}
+
+fn overhang_component(
+    entity: Entity,
+    collider: &Collider,
+    transform: &Transform,
+    spatial_query: &SpatialQueryPipeline,
+    velocity: Vec3,
+    dt: f32,
+) -> Option<Vec3> {
+    if velocity == Vec3::ZERO {
+        return None;
+    }
+
+    // Cast a segment (zero radius capsule) from our next position back towards us (sweeping a rectangle)
+    // If there is a ledge in front of us we will hit the edge of it
+    // We can use the normal of the hit to subtract off the component that is overhanging
+    let cast_capsule = Collider::capsule(0.01, 0.5);
+    let filter = SpatialQueryFilter::default().with_excluded_entities([entity]);
+    let collider_offset = collider_y_offset(collider);
+    let future_position = transform.translation - collider_offset + velocity * dt;
+
+    if let Some(hit) = spatial_query.cast_shape(
+        &cast_capsule,
+        future_position,
+        transform.rotation,
+        Dir3::new_unchecked((-velocity).normalize()),
+        &ShapeCastConfig::from_max_distance(0.5),
+        &filter,
+    ) {
+        let cast = spatial_query.cast_ray(
+            future_position + Vec3::Y * 0.125,
+            Dir3::new_unchecked(-Vec3::Y),
+            0.375,
+            false,
+            &filter,
+        );
+        // Make sure that this is actually a ledge, e.g. there is no ground in front of us
+        if cast.is_none() {
+            let normal = -hit.normal1;
+            let alignment = Vec3::dot(velocity, normal);
+            return Some(alignment * normal);
+        }
+    }
+    None
+}
+
+fn acceleration(
+    wish_direction: Vec3,
+    wish_speed: f32,
+    acceleration: f32,
+    velocity: Vec3,
+    dt: f32,
+) -> Vec3 {
+    let velocity_projection = Vec3::dot(velocity, wish_direction);
+    let add_speed = wish_speed - velocity_projection;
+    if add_speed <= 0.0 {
+        return Vec3::ZERO;
+    }
+
+    let acceleration_speed = f32::min(acceleration * wish_speed * dt, add_speed);
+    wish_direction * acceleration_speed
+}
+
+fn get_pressed(key_input: &Res<ButtonInput<KeyCode>>, key: KeyCode) -> f32 {
+    if key_input.pressed(key) {
+        1.0
+    } else {
+        0.0
+    }
+}
+
+fn get_axis(key_input: &Res<ButtonInput<KeyCode>>, key_pos: KeyCode, key_neg: KeyCode) -> f32 {
+    get_pressed(key_input, key_pos) - get_pressed(key_input, key_neg)
+}
+
+// ██████╗ ███████╗███╗   ██╗██████╗ ███████╗██████╗
+// ██╔══██╗██╔════╝████╗  ██║██╔══██╗██╔════╝██╔══██╗
+// ██████╔╝█████╗  ██╔██╗ ██║██║  ██║█████╗  ██████╔╝
+// ██╔══██╗██╔══╝  ██║╚██╗██║██║  ██║██╔══╝  ██╔══██╗
+// ██║  ██║███████╗██║ ╚████║██████╔╝███████╗██║  ██║
+// ╚═╝  ╚═╝╚══════╝╚═╝  ╚═══╝╚═════╝ ╚══════╝╚═╝  ╚═╝
+
+pub fn fps_controller_render(
+    mut render_query: Query<(&mut Transform, &RenderPlayer), With<RenderPlayer>>,
+    logical_query: Query<
+        (&Transform, &Collider, &FpsController, &CameraConfig),
+        (With<LogicalPlayer>, Without<RenderPlayer>),
+    >,
+) {
+    for (mut render_transform, render_player) in render_query.iter_mut() {
+        if let Ok((logical_transform, collider, controller, camera_config)) =
+            logical_query.get(render_player.logical_entity)
+        {
+            let collider_offset = collider_y_offset(collider);
+            let camera_offset = Vec3::Y * camera_config.height_offset;
+            render_transform.translation =
+                logical_transform.translation + collider_offset + camera_offset;
+            render_transform.rotation =
+                Quat::from_euler(EulerRot::YXZ, controller.yaw, controller.pitch, 0.0);
+        }
+    }
+}

--- a/src/controller_rapier.rs
+++ b/src/controller_rapier.rs
@@ -193,8 +193,10 @@ pub fn fps_controller_input(
     mut mouse_events: EventReader<MouseMotion>,
     mut query: Query<(&FpsController, &mut FpsControllerInput)>,
 ) {
-    for (controller, mut input) in query.iter_mut()
-        .filter(|(controller, _)| controller.enable_input) {
+    for (controller, mut input) in query
+        .iter_mut()
+        .filter(|(controller, _)| controller.enable_input)
+    {
         let mut mouse_delta = Vec2::ZERO;
         for mouse_event in mouse_events.read() {
             mouse_delta += mouse_event.delta;
@@ -265,7 +267,8 @@ pub fn fps_controller_move(
                     } else {
                         controller.fly_speed
                     };
-                    let mut move_to_world = Mat3::from_euler(EulerRot::YXZ, input.yaw, input.pitch, 0.0);
+                    let mut move_to_world =
+                        Mat3::from_euler(EulerRot::YXZ, input.yaw, input.pitch, 0.0);
                     move_to_world.z_axis *= -1.0; // Forward is -Z
                     move_to_world.y_axis = Vec3::Y; // Vertical movement aligned with world up
                     velocity.linvel = move_to_world * input.movement * fly_speed;
@@ -306,7 +309,8 @@ pub fn fps_controller_move(
                 wish_speed = f32::min(wish_speed, max_speed);
 
                 if let Some((hit, hit_details)) = unwrap_hit_details(ground_cast) {
-                    let has_traction = Vec3::dot(hit_details.normal1, Vec3::Y) > controller.traction_normal_cutoff;
+                    let has_traction =
+                        Vec3::dot(hit_details.normal1, Vec3::Y) > controller.traction_normal_cutoff;
 
                     // Only apply friction after at least one tick, allows b-hopping without losing speed
                     if controller.ground_tick >= 1 && has_traction {
@@ -339,7 +343,8 @@ pub fn fps_controller_move(
 
                     if has_traction {
                         let linear_velocity = velocity.linvel;
-                        velocity.linvel -= Vec3::dot(linear_velocity, hit_details.normal1) * hit_details.normal1;
+                        velocity.linvel -=
+                            Vec3::dot(linear_velocity, hit_details.normal1) * hit_details.normal1;
 
                         if input.jump {
                             velocity.linvel.y = controller.jump_speed;
@@ -395,7 +400,10 @@ pub fn fps_controller_move(
 
                 // Step offset really only works best for cylinders
                 // For capsules the player has to practically teleported to fully step up
-                if collider.as_cylinder().is_some() && controller.step_offset > f32::EPSILON && controller.ground_tick >= 1 {
+                if collider.as_cylinder().is_some()
+                    && controller.step_offset > f32::EPSILON
+                    && controller.ground_tick >= 1
+                {
                     // Try putting the player forward, but instead lifted upward by the step offset
                     // If we can find a surface below us, we can adjust our position to be on top of it
                     let future_position = transform.translation + velocity.linvel * dt;
@@ -405,11 +413,14 @@ pub fn fps_controller_move(
                         transform.rotation,
                         -Vec3::Y,
                         &collider,
-                        ShapeCastOptions::with_max_time_of_impact(controller.step_offset * SLIGHT_SCALE_DOWN),
+                        ShapeCastOptions::with_max_time_of_impact(
+                            controller.step_offset * SLIGHT_SCALE_DOWN,
+                        ),
                         filter,
                     );
                     if let Some((hit, details)) = unwrap_hit_details(cast) {
-                        let has_traction_on_ledge = Vec3::dot(details.normal1, Vec3::Y) > controller.traction_normal_cutoff;
+                        let has_traction_on_ledge =
+                            Vec3::dot(details.normal1, Vec3::Y) > controller.traction_normal_cutoff;
                         if has_traction_on_ledge {
                             transform.translation.y += controller.step_offset - hit.time_of_impact;
                         }
@@ -440,7 +451,8 @@ pub fn fps_controller_move(
                         &physics_context,
                         velocity.linvel,
                         dt,
-                    ).is_some()
+                    )
+                    .is_some()
                     {
                         velocity.linvel = Vec3::ZERO;
                     }
@@ -450,7 +462,9 @@ pub fn fps_controller_move(
     }
 }
 
-fn unwrap_hit_details(ground_cast: Option<(Entity, ShapeCastHit)>) -> Option<(ShapeCastHit, ShapeCastHitDetails)> {
+fn unwrap_hit_details(
+    ground_cast: Option<(Entity, ShapeCastHit)>,
+) -> Option<(ShapeCastHit, ShapeCastHitDetails)> {
     if let Some((_, hit)) = ground_cast {
         if let Some(details) = hit.details {
             return Some((hit, details));
@@ -459,17 +473,17 @@ fn unwrap_hit_details(ground_cast: Option<(Entity, ShapeCastHit)>) -> Option<(Sh
     None
 }
 
-
 /// Returns the offset that puts a point at the center of the player transform to the bottom of the collider.
 /// Needed for when we want to originate something at the foot of the player.
 fn collider_y_offset(collider: &Collider) -> Vec3 {
-    Vec3::Y * if let Some(cylinder) = collider.as_cylinder() {
-        cylinder.half_height()
-    } else if let Some(capsule) = collider.as_capsule() {
-        capsule.half_height() + capsule.radius()
-    } else {
-        panic!("Controller must use a cylinder or capsule collider")
-    }
+    Vec3::Y
+        * if let Some(cylinder) = collider.as_cylinder() {
+            cylinder.half_height()
+        } else if let Some(capsule) = collider.as_capsule() {
+            capsule.half_height() + capsule.radius()
+        } else {
+            panic!("Controller must use a cylinder or capsule collider")
+        }
 }
 
 /// Return a collider that is scaled laterally (XZ plane) but not vertically (Y axis).
@@ -478,7 +492,11 @@ fn scaled_collider_laterally(collider: &Collider, scale: f32) -> Collider {
         let new_cylinder = Collider::cylinder(cylinder.half_height(), cylinder.radius() * scale);
         new_cylinder
     } else if let Some(capsule) = collider.as_capsule() {
-        let new_capsule = Collider::capsule(capsule.segment().a(), capsule.segment().b(), capsule.radius() * scale);
+        let new_capsule = Collider::capsule(
+            capsule.segment().a(),
+            capsule.segment().b(),
+            capsule.radius() * scale,
+        );
         new_capsule
     } else {
         panic!("Controller must use a cylinder or capsule collider")
@@ -575,8 +593,10 @@ pub fn fps_controller_render(
         {
             let collider_offset = collider_y_offset(collider);
             let camera_offset = Vec3::Y * camera_config.height_offset;
-            render_transform.translation = logical_transform.translation + collider_offset + camera_offset;
-            render_transform.rotation = Quat::from_euler(EulerRot::YXZ, controller.yaw, controller.pitch, 0.0);
+            render_transform.translation =
+                logical_transform.translation + collider_offset + camera_offset;
+            render_transform.rotation =
+                Quat::from_euler(EulerRot::YXZ, controller.yaw, controller.pitch, 0.0);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,11 @@
-pub mod controller;
+#[cfg(feature = "avian")]
+mod controller_avian;
+#[cfg(feature = "rapier")]
+mod controller_rapier;
+
+pub mod controller {
+    #[cfg(feature = "avian")]
+    pub use crate::controller_avian::*;
+    #[cfg(feature = "rapier")]
+    pub use crate::controller_rapier::*;
+}


### PR DESCRIPTION
This PR adds support for `avian3d` via the `avian` feature. Here's a list of changes:

- Add a `controller_avian` module and `minimal_avian` example, feature gated behind the `avian` feature.
- Move the `controller` to `controller_rapier` and `minimal` example to `minimal_rapier` feature gating them behind the `rapier` feature.
- Add a `controller` module that reexports both controller modules, so you can still import with `use bevy_fps_controller::controller::*`

I think there is a bug with `overhang_component` in `controller_avian`, since edge fall prevention doesn't seem to be working 100% of the time -- I couldn't crack this unfortunately. My (minimal) testing has shown identical behavior otherwise.

I understand that this is a large diff, so if you'd like a different approach I'd be happy to comply.