### PR TITLE
fix(example/avian): TransformInterpolation needed to avoid jitter

### DIFF
--- a/examples/minimal_avian.rs
+++ b/examples/minimal_avian.rs
@@ -75,6 +75,7 @@ fn setup(mut commands: Commands, mut window: Query<&mut Window>, assets: Res<Ass
             Mass(1.0),
             GravityScale(0.0),
             Transform::from_translation(SPAWN_POINT),
+            TransformInterpolation,
             LogicalPlayer,
             FpsControllerInput {
                 pitch: -TAU / 12.0,


### PR DESCRIPTION
I don't think this is as intended? Though it perhaps shows that avian is running the physics at a lower refresh rate than the screen.

Rapier displays without jitter, but the jitter on avian is really quite poor without this setting enabled.