### PR TITLE
Do physics in fixed update, do visuals in update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_fps_controller"
-version = "17.0.0"
+version = "17.1.0"
 edition = "2021"
 authors = ["bevy_fps_controller"]
 repository = "https://github.com/qhdwight/bevy_fps_controller"

--- a/examples/minimal_avian.rs
+++ b/examples/minimal_avian.rs
@@ -23,7 +23,6 @@ fn main() {
         .insert_resource(ClearColor(Color::linear_rgb(0.83, 0.96, 0.96)))
         .add_plugins(DefaultPlugins)
         .add_plugins(PhysicsPlugins::default())
-        // .add_plugins(PhysicsDebugPlugin::default())
         .add_plugins(FpsControllerPlugin)
         .add_systems(Startup, setup)
         .add_systems(

--- a/examples/minimal_rapier.rs
+++ b/examples/minimal_rapier.rs
@@ -23,7 +23,6 @@ fn main() {
         .insert_resource(ClearColor(Color::linear_rgb(0.83, 0.96, 0.96)))
         .add_plugins(DefaultPlugins)
         .add_plugins(RapierPhysicsPlugin::<NoUserData>::default())
-        // .add_plugins(RapierDebugRenderPlugin::default())
         .add_plugins(FpsControllerPlugin)
         .add_systems(Startup, setup)
         .add_systems(

--- a/src/controller_avian.rs
+++ b/src/controller_avian.rs
@@ -6,50 +6,35 @@ use avian3d::{
 };
 use bevy::{input::mouse::MouseMotion, math::Vec3Swizzles, prelude::*};
 
-/// Manages the FPS controllers. Executes in `PreUpdate`, after bevy's internal
-/// input processing is finished.
-///
-/// If you need a system in `PreUpdate` to execute after FPS Controller's systems,
-/// Do it like so:
-///
-/// ```
-/// # use bevy::prelude::*;
-///
-/// struct MyPlugin;
-/// impl Plugin for MyPlugin {
-///     fn build(&self, app: &mut App) {
-///         app.add_systems(
-///             PreUpdate,
-///             my_system.after(bevy_fps_controller::controller::fps_controller_render),
-///         );
-///     }
-/// }
-///
-/// fn my_system() { }
-/// ```
 pub struct FpsControllerPlugin;
 
 impl Plugin for FpsControllerPlugin {
     fn build(&self, app: &mut App) {
-        use bevy::input::{gamepad, keyboard, mouse, touch};
-
-        app.add_systems(
-            PreUpdate,
-            (
-                fps_controller_input,
-                fps_controller_look,
-                fps_controller_move,
-                fps_controller_render,
+        app.init_resource::<DidFixedTimestepRunThisFrame>()
+            .add_systems(PreUpdate, clear_fixed_timestep_flag)
+            .add_systems(
+                FixedPreUpdate,
+                (set_fixed_time_step_flag, fps_controller_move),
             )
-                .chain()
-                .after(mouse::mouse_button_input_system)
-                .after(keyboard::keyboard_input_system)
-                .after(gamepad::gamepad_event_processing_system)
-                .after(gamepad::gamepad_connection_system)
-                .after(touch::touch_screen_input_system),
-        );
+            .add_systems(
+                RunFixedMainLoop,
+                (
+                    (fps_controller_input, fps_controller_look)
+                        .chain()
+                        .in_set(RunFixedMainLoopSystems::BeforeFixedMainLoop),
+                    (
+                        clear_input.run_if(did_fixed_timestep_run_this_frame),
+                        fps_controller_render,
+                    )
+                        .chain()
+                        .in_set(RunFixedMainLoopSystems::AfterFixedMainLoop),
+                ),
+            );
     }
 }
+
+#[derive(Resource, Default)]
+pub struct DidFixedTimestepRunThisFrame(bool);
 
 #[derive(PartialEq)]
 pub enum MoveMode {
@@ -129,6 +114,8 @@ pub struct FpsController {
     pub key_fly: KeyCode,
     pub key_crouch: KeyCode,
     pub experimental_enable_ledge_cling: bool,
+
+    pub previous_translation: Option<Vec3>,
 }
 
 impl Default for FpsController {
@@ -177,21 +164,49 @@ impl Default for FpsController {
             key_crouch: KeyCode::ControlLeft,
             sensitivity: 0.001,
             experimental_enable_ledge_cling: false, // Does not work well on Avian yet.
+
+            previous_translation: None,
         }
     }
 }
 
-// ██╗      ██████╗  ██████╗ ██╗ ██████╗
-// ██║     ██╔═══██╗██╔════╝ ██║██╔════╝
-// ██║     ██║   ██║██║  ███╗██║██║
-// ██║     ██║   ██║██║   ██║██║██║
-// ███████╗╚██████╔╝╚██████╔╝██║╚██████╗
-// ╚══════╝ ╚═════╝  ╚═════╝ ╚═╝ ╚═════╝
+//     __                _
+//    / /   ____  ____ _(_)____
+//   / /   / __ \/ __ `/ / ___/
+//  / /___/ /_/ / /_/ / / /__
+// /_____/\____/\__, /_/\___/
+//             /____/
 
 // Used as padding by camera pitching (up/down) to avoid spooky math problems
 const ANGLE_EPSILON: f32 = 0.001953125;
 
 const SLIGHT_SCALE_DOWN: f32 = 0.9375;
+
+fn clear_fixed_timestep_flag(
+    mut did_fixed_timestep_run_this_frame: ResMut<DidFixedTimestepRunThisFrame>,
+) {
+    did_fixed_timestep_run_this_frame.0 = false;
+}
+
+fn set_fixed_time_step_flag(
+    mut did_fixed_timestep_run_this_frame: ResMut<DidFixedTimestepRunThisFrame>,
+) {
+    did_fixed_timestep_run_this_frame.0 = true;
+}
+
+fn did_fixed_timestep_run_this_frame(
+    did_fixed_timestep_run_this_frame: Res<DidFixedTimestepRunThisFrame>,
+) -> bool {
+    did_fixed_timestep_run_this_frame.0
+}
+
+fn clear_input(mut input: Single<&mut FpsControllerInput>) {
+    input.movement = Vec3::ZERO;
+    input.sprint = false;
+    input.jump = false;
+    input.fly = false;
+    input.crouch = false;
+}
 
 pub fn fps_controller_input(
     key_input: Res<ButtonInput<KeyCode>>,
@@ -220,10 +235,10 @@ pub fn fps_controller_input(
             get_axis(&key_input, controller.key_up, controller.key_down),
             get_axis(&key_input, controller.key_forward, controller.key_back),
         );
-        input.sprint = key_input.pressed(controller.key_sprint);
-        input.jump = key_input.pressed(controller.key_jump);
-        input.fly = key_input.just_pressed(controller.key_fly);
-        input.crouch = key_input.pressed(controller.key_crouch);
+        input.sprint |= key_input.pressed(controller.key_sprint);
+        input.jump |= key_input.pressed(controller.key_jump);
+        input.fly |= key_input.just_pressed(controller.key_fly);
+        input.crouch |= key_input.pressed(controller.key_crouch);
     }
 }
 
@@ -235,7 +250,7 @@ pub fn fps_controller_look(mut query: Query<(&mut FpsController, &FpsControllerI
 }
 
 pub fn fps_controller_move(
-    time: Res<Time>,
+    time: Res<Time<Fixed>>,
     spatial_query_pipeline: Res<SpatialQueryPipeline>,
     mut query: Query<
         (
@@ -246,7 +261,7 @@ pub fn fps_controller_move(
             &mut Transform,
             &mut LinearVelocity,
         ),
-        With<LogicalPlayer>,
+        (With<LogicalPlayer>, Without<RenderPlayer>),
     >,
 ) {
     let dt = time.delta_secs();
@@ -254,6 +269,8 @@ pub fn fps_controller_move(
     for (entity, input, mut controller, mut collider, mut transform, mut velocity) in
         query.iter_mut()
     {
+        controller.previous_translation = Some(transform.translation);
+
         if input.fly {
             controller.move_mode = match controller.move_mode {
                 MoveMode::Noclip => MoveMode::Ground,
@@ -573,28 +590,32 @@ fn get_axis(key_input: &Res<ButtonInput<KeyCode>>, key_pos: KeyCode, key_neg: Ke
     get_pressed(key_input, key_pos) - get_pressed(key_input, key_neg)
 }
 
-// ██████╗ ███████╗███╗   ██╗██████╗ ███████╗██████╗
-// ██╔══██╗██╔════╝████╗  ██║██╔══██╗██╔════╝██╔══██╗
-// ██████╔╝█████╗  ██╔██╗ ██║██║  ██║█████╗  ██████╔╝
-// ██╔══██╗██╔══╝  ██║╚██╗██║██║  ██║██╔══╝  ██╔══██╗
-// ██║  ██║███████╗██║ ╚████║██████╔╝███████╗██║  ██║
-// ╚═╝  ╚═╝╚══════╝╚═╝  ╚═══╝╚═════╝ ╚══════╝╚═╝  ╚═╝
+//     ____                 __
+//    / __ \___  ____  ____/ /__  _____
+//   / /_/ / _ \/ __ \/ __  / _ \/ ___/
+//  / _, _/  __/ / / / /_/ /  __/ /
+// /_/ |_|\___/_/ /_/\__,_/\___/_/
 
 pub fn fps_controller_render(
+    fixed_time: Res<Time<Fixed>>,
     mut render_query: Query<(&mut Transform, &RenderPlayer), With<RenderPlayer>>,
     logical_query: Query<
         (&Transform, &Collider, &FpsController, &CameraConfig),
         (With<LogicalPlayer>, Without<RenderPlayer>),
     >,
 ) {
+    let t = fixed_time.overstep_fraction();
+
     for (mut render_transform, render_player) in render_query.iter_mut() {
         if let Ok((logical_transform, collider, controller, camera_config)) =
             logical_query.get(render_player.logical_entity)
         {
+            let previous = controller.previous_translation;
+            let current = logical_transform.translation;
+            let interpolated = previous.unwrap_or(current).lerp(current, t);
             let collider_offset = collider_y_offset(collider);
             let camera_offset = Vec3::Y * camera_config.height_offset;
-            render_transform.translation =
-                logical_transform.translation + collider_offset + camera_offset;
+            render_transform.translation = interpolated + collider_offset + camera_offset;
             render_transform.rotation =
                 Quat::from_euler(EulerRot::YXZ, controller.yaw, controller.pitch, 0.0);
         }

--- a/src/controller_rapier.rs
+++ b/src/controller_rapier.rs
@@ -5,11 +5,17 @@ use bevy_rapier3d::prelude::*;
 
 pub struct FpsControllerPlugin;
 
+#[derive(Resource, Default)]
+pub struct DidFixedTimestepRunThisFrame(bool);
+
 impl Plugin for FpsControllerPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<DidFixedTimestepRunThisFrame>()
             .add_systems(PreUpdate, clear_fixed_timestep_flag)
-            .add_systems(FixedPreUpdate, set_fixed_time_step_flag)
+            .add_systems(
+                FixedPreUpdate,
+                (set_fixed_time_step_flag, fps_controller_move),
+            )
             .add_systems(
                 RunFixedMainLoop,
                 (
@@ -23,8 +29,7 @@ impl Plugin for FpsControllerPlugin {
                         .chain()
                         .in_set(RunFixedMainLoopSystems::AfterFixedMainLoop),
                 ),
-            )
-            .add_systems(FixedPreUpdate, fps_controller_move);
+            );
     }
 }
 
@@ -159,9 +164,6 @@ impl Default for FpsController {
         }
     }
 }
-
-#[derive(Resource, Deref, DerefMut, Default)]
-pub struct DidFixedTimestepRunThisFrame(bool);
 
 //     __                _
 //    / /   ____  ____ _(_)____

--- a/src/controller_rapier.rs
+++ b/src/controller_rapier.rs
@@ -106,7 +106,7 @@ pub struct FpsController {
     pub key_fly: KeyCode,
     pub key_crouch: KeyCode,
 
-    pub previous_translation: Vec3,
+    pub previous_translation: Option<Vec3>,
 }
 
 impl Default for FpsController {
@@ -155,7 +155,7 @@ impl Default for FpsController {
             key_crouch: KeyCode::ControlLeft,
             sensitivity: 0.001,
 
-            previous_translation: Vec3::default(),
+            previous_translation: None,
         }
     }
 }
@@ -262,7 +262,7 @@ pub fn fps_controller_move(
     for (entity, input, mut controller, mut collider, mut transform, mut velocity) in
         query.iter_mut()
     {
-        controller.previous_translation = transform.translation;
+        controller.previous_translation = Some(transform.translation);
 
         if input.fly {
             controller.move_mode = match controller.move_mode {
@@ -615,7 +615,7 @@ pub fn fps_controller_render(
         {
             let previous = controller.previous_translation;
             let current = logical_transform.translation;
-            let interpolated = previous.lerp(current, t);
+            let interpolated = previous.unwrap_or(current).lerp(current, t);
             let collider_offset = collider_y_offset(collider);
             let camera_offset = Vec3::Y * camera_config.height_offset;
             render_transform.translation = interpolated + collider_offset + camera_offset;

--- a/src/controller_rapier.rs
+++ b/src/controller_rapier.rs
@@ -3,48 +3,22 @@ use std::f32::consts::*;
 use bevy::{input::mouse::MouseMotion, math::Vec3Swizzles, prelude::*};
 use bevy_rapier3d::prelude::*;
 
-/// Manages the FPS controllers. Executes in `PreUpdate`, after bevy's internal
-/// input processing is finished.
-///
-/// If you need a system in `PreUpdate` to execute after FPS Controller's systems,
-/// Do it like so:
-///
-/// ```
-/// # use bevy::prelude::*;
-///
-/// struct MyPlugin;
-/// impl Plugin for MyPlugin {
-///     fn build(&self, app: &mut App) {
-///         app.add_systems(
-///             PreUpdate,
-///             my_system.after(bevy_fps_controller::controller::fps_controller_render),
-///         );
-///     }
-/// }
-///
-/// fn my_system() { }
-/// ```
 pub struct FpsControllerPlugin;
 
 impl Plugin for FpsControllerPlugin {
     fn build(&self, app: &mut App) {
-        use bevy::input::{gamepad, keyboard, mouse, touch};
-
         app.add_systems(
-            PreUpdate,
+            RunFixedMainLoop,
             (
-                fps_controller_input,
-                fps_controller_look,
-                fps_controller_move,
-                fps_controller_render,
-            )
-                .chain()
-                .after(mouse::mouse_button_input_system)
-                .after(keyboard::keyboard_input_system)
-                .after(gamepad::gamepad_event_processing_system)
-                .after(gamepad::gamepad_connection_system)
-                .after(touch::touch_screen_input_system),
-        );
+                (fps_controller_input, fps_controller_look)
+                    .chain()
+                    .in_set(RunFixedMainLoopSystems::BeforeFixedMainLoop),
+                fps_controller_render
+                    .chain()
+                    .in_set(RunFixedMainLoopSystems::AfterFixedMainLoop),
+            ),
+        )
+        .add_systems(FixedPreUpdate, fps_controller_move);
     }
 }
 
@@ -125,6 +99,8 @@ pub struct FpsController {
     pub key_jump: KeyCode,
     pub key_fly: KeyCode,
     pub key_crouch: KeyCode,
+
+    pub previous_translation: Vec3,
 }
 
 impl Default for FpsController {
@@ -172,16 +148,21 @@ impl Default for FpsController {
             key_fly: KeyCode::KeyF,
             key_crouch: KeyCode::ControlLeft,
             sensitivity: 0.001,
+
+            previous_translation: Vec3::default(),
         }
     }
 }
 
-// ██╗      ██████╗  ██████╗ ██╗ ██████╗
-// ██║     ██╔═══██╗██╔════╝ ██║██╔════╝
-// ██║     ██║   ██║██║  ███╗██║██║
-// ██║     ██║   ██║██║   ██║██║██║
-// ███████╗╚██████╔╝╚██████╔╝██║╚██████╗
-// ╚══════╝ ╚═════╝  ╚═════╝ ╚═╝ ╚═════╝
+#[derive(Resource, Deref, DerefMut, Default)]
+pub struct DidFixedTimestepRunThisFrame(bool);
+
+//     __                _
+//    / /   ____  ____ _(_)____
+//   / /   / __ \/ __ `/ / ___/
+//  / /___/ /_/ / /_/ / / /__
+// /_____/\____/\__, /_/\___/
+//             /____/
 
 // Used as padding by camera pitching (up/down) to avoid spooky math problems
 const ANGLE_EPSILON: f32 = 0.001953125;
@@ -230,22 +211,27 @@ pub fn fps_controller_look(mut query: Query<(&mut FpsController, &FpsControllerI
 }
 
 pub fn fps_controller_move(
-    time: Res<Time>,
+    time: Res<Time<Fixed>>,
     physics_context: ReadRapierContext,
-    mut query: Query<(
-        Entity,
-        &FpsControllerInput,
-        &mut FpsController,
-        &mut Collider,
-        &mut Transform,
-        &mut Velocity,
-    )>,
+    mut query: Query<
+        (
+            Entity,
+            &FpsControllerInput,
+            &mut FpsController,
+            &mut Collider,
+            &mut Transform,
+            &mut Velocity,
+        ),
+        (With<LogicalPlayer>, Without<RenderPlayer>),
+    >,
 ) {
     let dt = time.delta_secs();
 
     for (entity, input, mut controller, mut collider, mut transform, mut velocity) in
         query.iter_mut()
     {
+        controller.previous_translation = transform.translation;
+
         if input.fly {
             controller.move_mode = match controller.move_mode {
                 MoveMode::Noclip => MoveMode::Ground,
@@ -285,7 +271,9 @@ pub fn fps_controller_move(
                     // Consider when the controller is right up against a wall
                     // We do not want the shape cast to detect it,
                     // so provide a slightly smaller collider in the XZ plane
-                    scaled_collider_laterally(&collider, SLIGHT_SCALE_DOWN).raw.as_ref(),
+                    scaled_collider_laterally(&collider, SLIGHT_SCALE_DOWN)
+                        .raw
+                        .as_ref(),
                     ShapeCastOptions::with_max_time_of_impact(controller.grounded_distance),
                     filter,
                 );
@@ -530,7 +518,7 @@ fn overhang_component(
         let cast = physics_context.single().unwrap().cast_ray(
             future_position + Vec3::Y * 0.125,
             -Vec3::Y,
-            0.375,
+            0.375.into(),
             false,
             filter,
         );
@@ -573,28 +561,32 @@ fn get_axis(key_input: &Res<ButtonInput<KeyCode>>, key_pos: KeyCode, key_neg: Ke
     get_pressed(key_input, key_pos) - get_pressed(key_input, key_neg)
 }
 
-// ██████╗ ███████╗███╗   ██╗██████╗ ███████╗██████╗
-// ██╔══██╗██╔════╝████╗  ██║██╔══██╗██╔════╝██╔══██╗
-// ██████╔╝█████╗  ██╔██╗ ██║██║  ██║█████╗  ██████╔╝
-// ██╔══██╗██╔══╝  ██║╚██╗██║██║  ██║██╔══╝  ██╔══██╗
-// ██║  ██║███████╗██║ ╚████║██████╔╝███████╗██║  ██║
-// ╚═╝  ╚═╝╚══════╝╚═╝  ╚═══╝╚═════╝ ╚══════╝╚═╝  ╚═╝
+//     ____                 __
+//    / __ \___  ____  ____/ /__  _____
+//   / /_/ / _ \/ __ \/ __  / _ \/ ___/
+//  / _, _/  __/ / / / /_/ /  __/ /
+// /_/ |_|\___/_/ /_/\__,_/\___/_/
 
 pub fn fps_controller_render(
+    fixed_time: Res<Time<Fixed>>,
     mut render_query: Query<(&mut Transform, &RenderPlayer), With<RenderPlayer>>,
     logical_query: Query<
         (&Transform, &Collider, &FpsController, &CameraConfig),
         (With<LogicalPlayer>, Without<RenderPlayer>),
     >,
 ) {
+    let t = fixed_time.overstep_fraction();
+
     for (mut render_transform, render_player) in render_query.iter_mut() {
         if let Ok((logical_transform, collider, controller, camera_config)) =
             logical_query.get(render_player.logical_entity)
         {
+            let previous = controller.previous_translation;
+            let current = logical_transform.translation;
+            let interpolated = previous.lerp(current, t);
             let collider_offset = collider_y_offset(collider);
             let camera_offset = Vec3::Y * camera_config.height_offset;
-            render_transform.translation =
-                logical_transform.translation + collider_offset + camera_offset;
+            render_transform.translation = interpolated + collider_offset + camera_offset;
             render_transform.rotation =
                 Quat::from_euler(EulerRot::YXZ, controller.yaw, controller.pitch, 0.0);
         }


### PR DESCRIPTION
This was a pretty glaringly big issue which is kind of embarrassing.

Before we were doing physics in `Update` which is not good since it is essentially the render loop and does not run in a fixed time step.

Now we do physics in `FixedUpdate` which is where Rapier/Avian update internally. And then for visuals we interpolate.

There is a great explanation here that is less terse than the above: https://github.com/bevyengine/bevy/blob/main/examples/movement/physics_in_fixed_timestep.rs

Closes #54